### PR TITLE
add ability to set the auth_source from config, and use it when creat…

### DIFF
--- a/lib/fluent/plugin/mongo_auth.rb
+++ b/lib/fluent/plugin/mongo_auth.rb
@@ -6,6 +6,8 @@ module Fluent
         config_param :user, :string, default: nil
         desc "MongoDB password"
         config_param :password, :string, default: nil, secret: true
+        desc "MongoDB authentication database"
+        config_param :auth_source, :string, default: nil
       }
     end
   end
@@ -14,7 +16,11 @@ module Fluent
     def authenticate(client)
       unless @user.nil? || @password.nil?
         begin
-          client = client.with(user: @user, password: @password)
+          if @auth_source.nil?
+            client = client.with(user: @user, password: @password)
+          else
+            client = client.with(user: @user, password: @password, auth_source: @auth_source)
+          end
         rescue Mongo::Auth::Unauthorized => e
           log.fatal e
           exit!


### PR DESCRIPTION
…ing the mongo client.

mongo recommends authenticating from the admin db, and this is now easy with the nice changes you made to update the ruby mongo driver.

if you set auth_source in your fluentd config, this change passes that setting along at client creation time.

for example, in my fluentd.conf i have:
  @type mongo2

  # authentication
  auth_source admin
  user myuser
  password mypassword

 ....

Note: this is literally my first look at ruby, so if I haven't done something here the proper ruby way, please feel free to change it :)
